### PR TITLE
Fix warnings

### DIFF
--- a/lib/mustang/v8/function.rb
+++ b/lib/mustang/v8/function.rb
@@ -2,6 +2,7 @@ module Mustang
   module V8
     class Function
       def call(*args, &block)
+        @receiver ||= nil
         call_on(@receiver, *args, &block);
       end
 

--- a/lib/mustang/v8/string.rb
+++ b/lib/mustang/v8/string.rb
@@ -10,6 +10,7 @@ module Mustang
         end
       end
 
+      undef_method :to_s
       alias_method :to_s, :to_utf8
 
       include Comparable


### PR DESCRIPTION
Fixes two 1.8 warnings.
- `@receiver` is uninitialized
-  Redefining `to_s` on String

Wasn't sure how to set warnings on in spec. I just ran the tests with `RUBYOPT="-w" rake`
